### PR TITLE
Feat: Update link to TuviKeyDerivationLib.

### DIFF
--- a/TuviPgpLib/Entities/Exceptions.cs
+++ b/TuviPgpLib/Entities/Exceptions.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLib/Entities/PgpKeyBundle.cs
+++ b/TuviPgpLib/Entities/PgpKeyBundle.cs
@@ -1,0 +1,57 @@
+﻿///////////////////////////////////////////////////////////////////////////////
+//   Copyright 2023 Eppie (https://eppie.io)
+//
+//   Licensed under the Apache License, Version 2.0(the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+///////////////////////////////////////////////////////////////////////////////
+
+using System.Linq;
+
+namespace TuviPgpLib.Entities
+{
+    public class PgpPublicKeyBundle : PgpKeyBundle
+    {
+    }
+
+    public class PgpSecretKeyBundle : PgpKeyBundle
+    {
+    }
+
+    public class PgpKeyBundle
+    {
+#pragma warning disable CA1819 // Properties should not return arrays
+        public byte[] Data { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PgpKeyBundle other)
+            {
+                if ((Data == null && other.Data == null) ||
+                     Data.SequenceEqual(other.Data))
+                {
+                    return true;
+                }
+                return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/TuviPgpLib/Entities/PgpKeyBundle.cs
+++ b/TuviPgpLib/Entities/PgpKeyBundle.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 ///////////////////////////////////////////////////////////////////////////////
 
+using System;
 using System.Linq;
 
 namespace TuviPgpLib.Entities
@@ -26,7 +27,7 @@ namespace TuviPgpLib.Entities
     {
     }
 
-    public class PgpKeyBundle
+    public class PgpKeyBundle : IEquatable<PgpKeyBundle>
     {
 #pragma warning disable CA1819 // Properties should not return arrays
         public byte[] Data { get; set; }
@@ -34,19 +35,21 @@ namespace TuviPgpLib.Entities
 
         public override bool Equals(object obj)
         {
-            if (obj is PgpKeyBundle other)
+            return Equals(obj as PgpKeyBundle);
+        }
+
+        public bool Equals(PgpKeyBundle other)
+        {
+            if (this == other)
             {
-                if ((Data == null && other.Data == null) ||
-                     Data.SequenceEqual(other.Data))
-                {
-                    return true;
-                }
+                return true;
+            }
+            if (other == null)
+            {
                 return false;
             }
-            else
-            {
-                return false;
-            }
+
+            return Data.SequenceEqual(other.Data);
         }
 
         public override int GetHashCode()

--- a/TuviPgpLib/Entities/PgpKeyInfo.cs
+++ b/TuviPgpLib/Entities/PgpKeyInfo.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLib/Entities/UserIdentity.cs
+++ b/TuviPgpLib/Entities/UserIdentity.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLib/IEllipticCurveCryptographyContext.cs
+++ b/TuviPgpLib/IEllipticCurveCryptographyContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLib/IExternalStorageBasedPgpContext.cs
+++ b/TuviPgpLib/IExternalStorageBasedPgpContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLib/IKeyStorage.cs
+++ b/TuviPgpLib/IKeyStorage.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 using KeyDerivation.Keys;
 using System.Threading;
 using System.Threading.Tasks;
+using TuviPgpLib.Entities;
 
 namespace TuviPgpLib
 {

--- a/TuviPgpLib/ITuviPgpContext.cs
+++ b/TuviPgpLib/ITuviPgpContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibImpl/EccPgpContext.cs
+++ b/TuviPgpLibImpl/EccPgpContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibImpl/Extensions.cs
+++ b/TuviPgpLibImpl/Extensions.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibImpl/ExternalStorageBasedPgpContext.cs
+++ b/TuviPgpLibImpl/ExternalStorageBasedPgpContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using TuviPgpLib;
+using TuviPgpLib.Entities;
 
 namespace TuviPgpLibImpl
 {

--- a/TuviPgpLibImpl/TuviPgpContext.cs
+++ b/TuviPgpLibImpl/TuviPgpContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibTests/EccPgpContextTests.cs
+++ b/TuviPgpLibTests/EccPgpContextTests.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibTests/ExternalStorageBasedPgpContextTests.cs
+++ b/TuviPgpLibTests/ExternalStorageBasedPgpContextTests.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibTests/MockPgpKeyStorage.cs
+++ b/TuviPgpLibTests/MockPgpKeyStorage.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 using Moq;
+using TuviPgpLib.Entities;
 
 namespace TuviPgpLibTests
 {

--- a/TuviPgpLibTests/TestData.cs
+++ b/TuviPgpLibTests/TestData.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.

--- a/TuviPgpLibTests/TuviPgpContextTests.cs
+++ b/TuviPgpLibTests/TuviPgpContextTests.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2022 Eppie (https://eppie.io)
+//   Copyright 2023 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update link to TuviKeyDerivationLib. 
Add PgpKeyBundle (removed from TuviKeyDerivationLib). 
Update License text (2022 to 2023)