### PR TITLE
Feat: remove parameters (password, keyIndex). Correct tests and calls.

### DIFF
--- a/TuviPgpLib/IEllipticCurveCryptographyContext.cs
+++ b/TuviPgpLib/IEllipticCurveCryptographyContext.cs
@@ -29,6 +29,6 @@ namespace TuviPgpLib
         /// ECC keys will be derived from <paramref name="masterKey"/> for specified <paramref name="userIdentity"/>
         /// with choosen <paramref name="keyIndex"/> and protected with <paramref name="password"/>.
         /// </summary>
-        void DeriveKeyPair(MasterKey masterKey, string userIdentity, string password, int keyIndex);
+        void DeriveKeyPair(MasterKey masterKey, string userIdentity);
     }
 }

--- a/TuviPgpLib/IEllipticCurveCryptographyContext.cs
+++ b/TuviPgpLib/IEllipticCurveCryptographyContext.cs
@@ -26,8 +26,7 @@ namespace TuviPgpLib
     {
         /// <summary>
         /// Create new PGP keyring.
-        /// ECC keys will be derived from <paramref name="masterKey"/> for specified <paramref name="userIdentity"/>
-        /// with choosen <paramref name="keyIndex"/> and protected with <paramref name="password"/>.
+        /// ECC keys will be derived from <paramref name="masterKey"/> for specified <paramref name="userIdentity"/>.
         /// </summary>
         void DeriveKeyPair(MasterKey masterKey, string userIdentity);
     }

--- a/TuviPgpLibImpl/EccPgpContext.cs
+++ b/TuviPgpLibImpl/EccPgpContext.cs
@@ -65,12 +65,10 @@ namespace TuviPgpLibImpl
 
         /// <summary>
         /// Realization of IEllipticCurveCryptographyPgpContext interface. 
-        /// Creates keypair and add (import) it to the current context.
+        /// Creates keypairs and add (import) it to the current context.
         /// </summary>
         /// <param name="masterKey">Master key.</param>
         /// <param name="userIdentity">User Id (email).</param>
-        /// <param name="password">Password.</param>
-        /// <param name="keyIndex">Key Index. Equals to 0 if not set.</param>
         public void DeriveKeyPair(MasterKey masterKey, string userIdentity)
         {
             if (masterKey == null)
@@ -89,6 +87,12 @@ namespace TuviPgpLibImpl
             Import(generator.GeneratePublicKeyRing());
         }
 
+        /// <summary>
+        /// Creates child keypair from choosen derivationKey with specific keyIndex.
+        /// </summary>
+        /// <param name="derivationKey">Derivation key.</param>
+        /// <param name="keyIndex">Key index.</param>
+        /// <returns>Derived key pair.</returns>
         public static AsymmetricCipherKeyPair DeriveKeyPair(PrivateDerivationKey derivationKey, int keyIndex)
         {
             const string algorithm = "EC";
@@ -184,6 +188,12 @@ namespace TuviPgpLibImpl
             return subpacketGenerator;
         }
 
+        /// <summary>
+        /// Return signing (not master) key of choosen mailbox
+        /// </summary>
+        /// <param name="mailbox">Mailbox.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Signing key.</returns>
         public override PgpSecretKey GetSigningKey(MailboxAddress mailbox, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (mailbox == null)

--- a/TuviPgpLibImpl/EccPgpContext.cs
+++ b/TuviPgpLibImpl/EccPgpContext.cs
@@ -112,7 +112,7 @@ namespace TuviPgpLibImpl
             return new AsymmetricCipherKeyPair(publicKey, privateKey);
         }
 
-        private PgpKeyRingGenerator CreateEllipticCurveKeyRingGenerator(MasterKey masterKey, string userIdentity, SymmetricKeyAlgorithmTag algorithm = SymmetricKeyAlgorithmTag.Aes128)
+        private PgpKeyRingGenerator CreateEllipticCurveKeyRingGenerator(MasterKey masterKey, string userIdentity)
         {
             int keyIndex = 0;
             string password = string.Empty;
@@ -137,7 +137,7 @@ namespace TuviPgpLibImpl
                 certificationLevel: PgpSignature.PositiveCertification,
                 masterKey: pgpMasterKeyPair,
                 id: userIdentity,
-                encAlgorithm: algorithm,
+                encAlgorithm: SymmetricKeyAlgorithmTag.Aes128,
                 rawPassPhrase: Encoding.UTF8.GetBytes(password),
                 useSha1: true,
                 hashedPackets: certificationSubpacketGenerator.Generate(),

--- a/TuviPgpLibImpl/EccPgpContext.cs
+++ b/TuviPgpLibImpl/EccPgpContext.cs
@@ -71,7 +71,7 @@ namespace TuviPgpLibImpl
         /// <param name="userIdentity">User Id (email).</param>
         /// <param name="password">Password.</param>
         /// <param name="keyIndex">Key Index. Equals to 0 if not set.</param>
-        public void DeriveKeyPair(MasterKey masterKey, string userIdentity, string password, int keyIndex = 0)
+        public void DeriveKeyPair(MasterKey masterKey, string userIdentity)
         {
             if (masterKey == null)
             {
@@ -83,17 +83,7 @@ namespace TuviPgpLibImpl
                 throw new ArgumentNullException(nameof(userIdentity), "Parameter is not set.");
             }
 
-            if (password == null)
-            {
-                throw new ArgumentNullException(nameof(password), "Parameter is not set.");
-            }
-
-            if (keyIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(keyIndex), "KeyIndex should be greater than or equal to 0.");
-            }
-
-            var generator = CreateEllipticCurveKeyRingGenerator(masterKey, userIdentity, password, keyIndex);
+            var generator = CreateEllipticCurveKeyRingGenerator(masterKey, userIdentity);
 
             Import(generator.GenerateSecretKeyRing());
             Import(generator.GeneratePublicKeyRing());
@@ -118,11 +108,13 @@ namespace TuviPgpLibImpl
             return new AsymmetricCipherKeyPair(publicKey, privateKey);
         }
 
-        private PgpKeyRingGenerator CreateEllipticCurveKeyRingGenerator(MasterKey masterKey, string userIdentity, string password, int keyIndex, SymmetricKeyAlgorithmTag algorithm = SymmetricKeyAlgorithmTag.Aes128)
+        private PgpKeyRingGenerator CreateEllipticCurveKeyRingGenerator(MasterKey masterKey, string userIdentity, SymmetricKeyAlgorithmTag algorithm = SymmetricKeyAlgorithmTag.Aes128)
         {
-            int masterKeyIndex = 0;
+            int keyIndex = 0;
+            string password = string.Empty;
+
             PrivateDerivationKey accountKey = DerivationKeyFactory.CreatePrivateDerivationKey(masterKey, userIdentity);
-            AsymmetricCipherKeyPair masterKeyPair = DeriveKeyPair(accountKey, masterKeyIndex);
+            AsymmetricCipherKeyPair masterKeyPair = DeriveKeyPair(accountKey, keyIndex);
             PgpKeyPair pgpMasterKeyPair = new PgpKeyPair(PublicKeyAlgorithmTag.ECDsa, masterKeyPair, KeyCreationTime);
             PgpSignatureSubpacketGenerator certificationSubpacketGenerator = CreateSubpacketGenerator(KeyType.MasterKey, ExpirationTime);
 

--- a/TuviPgpLibTests/EccPgpContextTests.cs
+++ b/TuviPgpLibTests/EccPgpContextTests.cs
@@ -47,7 +47,7 @@ namespace TuviPgpLibTests
         public async Task EссEncryptAndDecryptAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();
@@ -73,7 +73,7 @@ namespace TuviPgpLibTests
             using Stream encryptedData = new MemoryStream();
             using (EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false))
             {
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
 
                 using Stream inputData = new MemoryStream();
                 using var messageBody = new TextPart() { Text = TestData.TextContent };
@@ -85,7 +85,7 @@ namespace TuviPgpLibTests
 
             using (EccPgpContext anotherCtx = await InitializeEccPgpContextAsync().ConfigureAwait(false))
             {
-                anotherCtx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+                anotherCtx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
 
                 encryptedData.Position = 0;
                 var mime = anotherCtx.Decrypt(encryptedData);
@@ -100,21 +100,15 @@ namespace TuviPgpLibTests
         public async Task DeterministicEccKeyDerivation()
         {
             string ToHex(byte[] data) => string.Concat(data.Select(x => x.ToString("x2", CultureInfo.CurrentCulture)));
-            
-            for (int keyIndex = 0; keyIndex < 3; keyIndex++)
-            {
-                using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-                
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "", keyIndex);
-
-                var listOfKeys = ctx.GetPublicKeys(new List<MailboxAddress> { TestData.GetAccount().GetMailbox() });
-                PgpPublicKey key = listOfKeys.First();
-
-                ECPublicKeyParameters? publicKey = key.GetKey() as ECPublicKeyParameters;
-                Assert.That(publicKey, Is.Not.Null, "PublicKey can not be a null");
-                Assert.That(ToHex(publicKey.Q.GetEncoded()), Is.EqualTo(TestData.PgpPubKey[keyIndex]),
-                                "Public key is not equal to determined");
-            }
+           
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);            
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            var listOfKeys = ctx.GetPublicKeys(new List<MailboxAddress> { TestData.GetAccount().GetMailbox() });
+            PgpPublicKey key = listOfKeys.First();
+            ECPublicKeyParameters? publicKey = key.GetKey() as ECPublicKeyParameters;
+            Assert.That(publicKey, Is.Not.Null, "PublicKey can not be a null");
+            Assert.That(ToHex(publicKey.Q.GetEncoded()), Is.EqualTo(TestData.PgpPubKey),
+                            "Public key is not equal to determined");           
         }
 
         [Test]
@@ -122,7 +116,7 @@ namespace TuviPgpLibTests
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
             Assert.IsFalse(ctx.CanSign(TestData.GetAccount().GetMailbox()));
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "", 0);
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
             Assert.IsTrue(ctx.CanSign(TestData.GetAccount().GetMailbox()));
         }
 
@@ -130,7 +124,7 @@ namespace TuviPgpLibTests
         public async Task EссSignAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();
@@ -154,7 +148,7 @@ namespace TuviPgpLibTests
         public async Task EссEncryptAndSignAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();

--- a/TuviPgpLibTests/TestData.cs
+++ b/TuviPgpLibTests/TestData.cs
@@ -93,11 +93,8 @@ namespace TuviPgpLibTests
             }
         };
 
-        public static string[] PgpPubKey = new string[] {
-            "046d56e80fb311a80bc96b461ef4c4323167577dc12c82f56c90c9e46ab61ac8a223ea268e080f0d72d7db8e048d7eee27f86a4a11b77b55ac95eeaaf63ae4494a",
-            "04c7543b4cccd45dbd92dbf32c7e1df972277ad65d65f2e6cf000c425f8e14bbdfadee74c2c48a2e295795fb37e39aa45274f156cb30f741119e358606f451b75e",
-            "041181d2bbabf8fbd69ae9a973dc31f1b2874405bbd7792472907f48fc8d29f11b9f52cfcd7c50f96760f9d9e40bc335cee04ca7a38610448823c1c1c5296c0163"
-        };
+        public static string PgpPubKey = 
+            "046d56e80fb311a80bc96b461ef4c4323167577dc12c82f56c90c9e46ab61ac8a223ea268e080f0d72d7db8e048d7eee27f86a4a11b77b55ac95eeaaf63ae4494a";
 
         public static TestAccount GetAccount()
         {

--- a/TuviPgpLibTests/TuviPgpContextTests.cs
+++ b/TuviPgpLibTests/TuviPgpContextTests.cs
@@ -50,7 +50,7 @@ namespace TuviPgpLibTests
             {
                 var identities = new List<UserIdentity> { TestData.GetAccount().GetUserIdentity() };
 
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
                 ctx.ExportPublicKeys(identities, publicKeyData, isArmored);
                 ctx.ExportSecretKeys(TestData.GetAccount().GetPgpIdentity(), secretKeyData, isArmored);
 
@@ -76,11 +76,11 @@ namespace TuviPgpLibTests
             using Stream secretKeyData = new MemoryStream();
             using (TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false))
             {
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
                 var publicKeyId = ctx.GetPublicKeysInfo().First().KeyId;
 
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetSecondAccount().GetPgpIdentity(), "");
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetThirdAccount().GetPgpIdentity(), "");
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetSecondAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetThirdAccount().GetPgpIdentity());
                 Assert.That(ctx.GetPublicKeysInfo().Count, Is.EqualTo(3));
 
                 Assert.DoesNotThrowAsync(() => ctx.ExportPublicKeyRingAsync(publicKeyId, publicKeyArmored, default));
@@ -135,7 +135,7 @@ namespace TuviPgpLibTests
         public async Task SecretKeyExistAsync()
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
             bool isKeyExist = ctx.IsSecretKeyExist(TestData.GetAccount().GetUserIdentity());
 
             Assert.IsTrue(isKeyExist, "Secret key has to exist");
@@ -145,7 +145,7 @@ namespace TuviPgpLibTests
         public async Task SecretKeyNotExistAsync()
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.WrongPgpIdentity, "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.WrongPgpIdentity);
             bool isKeyExist = ctx.IsSecretKeyExist(TestData.GetAccount().GetUserIdentity());
 
             Assert.IsFalse(isKeyExist, "Secret key has not to exist");
@@ -156,8 +156,8 @@ namespace TuviPgpLibTests
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
 
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
-            var keysInfo = ctx.GetPublicKeysInfo();
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            var keysInfo = ctx.GetPublicKeysInfo(); 
 
             Assert.That(keysInfo.Count, Is.EqualTo(1));
 
@@ -172,7 +172,7 @@ namespace TuviPgpLibTests
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
             UserIdentity? nullIdentity = null;
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), "");
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
             Assert.Throws<ArgumentNullException>(() => ctx.IsSecretKeyExist(nullIdentity));
         }
 


### PR DESCRIPTION
remove parameters (password, keyIndex) from key generation function. 
Correct tests and calls.