### PR TITLE
feat: Enhance EccPgpContext with BIP44 key derivation and improved key generation

### DIFF
--- a/TuviPgpLib/IEllipticCurveCryptographyContext.cs
+++ b/TuviPgpLib/IEllipticCurveCryptographyContext.cs
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//   Copyright 2023 Eppie (https://eppie.io)
+//   Copyright 2025 Eppie (https://eppie.io)
 //
 //   Licensed under the Apache License, Version 2.0(the "License");
 //   you may not use this file except in compliance with the License.
@@ -25,17 +25,13 @@ namespace TuviPgpLib
     public interface IEllipticCurveCryptographyPgpContext
     {
         /// <summary>
-        /// Create new PGP keyring.
-        /// ECC keys will be derived from <paramref name="masterKey"/> for specified <paramref name="userIdentity"/>.
+        /// Derives a PGP key pair from the master key and tag, associating it with the user identity.
+        /// Generates ECC keys (secp256k1) and imports them into the PGP key ring.
         /// </summary>
-        void DeriveKeyPair(MasterKey masterKey, string userIdentity);
-
-        /// <summary>
-        /// Adds new keys to the PGP key ring
-        /// </summary>
-        /// <param name="masterKey">Master key</param>
-        /// <param name="userIdentity">User identity, it's used to search keys in the ring</param>
-        /// <param name="tag">Tag, which is used for deterministic key generation</param>
+        /// <param name="masterKey">The master key for key derivation.</param>
+        /// <param name="userIdentity">The user identity (e.g., email) associated with the PGP key ring.</param>
+        /// <param name="tag">The tag for deterministic key derivation.</param>
+        /// <exception cref="ArgumentNullException">Thrown if any parameter is null.</exception>
         void DeriveKeyPair(MasterKey masterKey, string userIdentity, string tag);
     }
 }

--- a/TuviPgpLibTests/EccPgpContextTests.cs
+++ b/TuviPgpLibTests/EccPgpContextTests.cs
@@ -48,7 +48,7 @@ namespace TuviPgpLibTests
         public async Task EссEncryptAndDecryptAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();
@@ -74,7 +74,7 @@ namespace TuviPgpLibTests
             using Stream encryptedData = new MemoryStream();
             using (EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false))
             {
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
                 using Stream inputData = new MemoryStream();
                 using var messageBody = new TextPart() { Text = TestData.TextContent };
@@ -86,7 +86,7 @@ namespace TuviPgpLibTests
 
             using (EccPgpContext anotherCtx = await InitializeEccPgpContextAsync().ConfigureAwait(false))
             {
-                anotherCtx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+                anotherCtx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
                 encryptedData.Position = 0;
                 var mime = anotherCtx.Decrypt(encryptedData);
@@ -103,7 +103,7 @@ namespace TuviPgpLibTests
             string ToHex(byte[] data) => string.Concat(data.Select(x => x.ToString("x2", CultureInfo.CurrentCulture)));
 
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
             var allPublicKeys = ctx.EnumerateSecretKeys().ToList();
             Assert.That(allPublicKeys.Count, Is.EqualTo(3));
@@ -131,7 +131,7 @@ namespace TuviPgpLibTests
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
             Assert.That(ctx.CanSign(TestData.GetAccount().GetMailbox()), Is.False);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             Assert.That(ctx.CanSign(TestData.GetAccount().GetMailbox()), Is.True);
         }
 
@@ -139,7 +139,7 @@ namespace TuviPgpLibTests
         public async Task EссSignAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();
@@ -163,7 +163,7 @@ namespace TuviPgpLibTests
         public async Task EссEncryptAndSignAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
 
             using Stream inputData = new MemoryStream();
             using Stream encryptedData = new MemoryStream();
@@ -193,16 +193,16 @@ namespace TuviPgpLibTests
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
             Assert.Throws<ArgumentNullException>(
-                () => ctx.DeriveKeyPair(null, TestData.GetAccount().GetPgpIdentity()));
+                () => ctx.DeriveKeyPair(null, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity()));
             Assert.Throws<ArgumentNullException>(
-                () => ctx.DeriveKeyPair(TestData.MasterKey, null));
+                () => ctx.DeriveKeyPair(TestData.MasterKey, null, null));
         }
 
         [Test]
         public async Task EссCanSignNullParameterThrowArgumentNullExceptionAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             Assert.That(ctx.CanSign(TestData.GetAccount().GetMailbox()), Is.True);
             Assert.Throws<ArgumentNullException>(
                () => ctx.CanSign(null));
@@ -212,7 +212,7 @@ namespace TuviPgpLibTests
         public async Task EссGetSigningKeyAsync()
         {
             using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             Assert.That(ctx.GetSigningKey(TestData.GetAccount().GetMailbox()), Is.Not.Null);
         }
 
@@ -224,9 +224,138 @@ namespace TuviPgpLibTests
                () => ctx.GetSigningKey(TestData.GetAccount().GetMailbox()));
             Assert.Throws<ArgumentNullException>(
                () => ctx.GetSigningKey(null));
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             Assert.Throws<ArgumentNullException>(
                () => ctx.GetSigningKey(null));
+        }
+
+        const int CoinType = 3630;
+
+        [Test]
+        public async Task EccBip44KeyDerivationForDecTest()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            int account = 0;
+            int channel = 10; // Mail channel
+            int index = 0;
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+
+            ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, account, channel, index);
+
+            var publicKeys = ctx.EnumeratePublicKeyRings().ToList();
+            var secretKeys = ctx.EnumerateSecretKeyRings().ToList();
+            Assert.That(publicKeys.Count, Is.GreaterThan(0), "No public keys generated");
+            Assert.That(secretKeys.Count, Is.GreaterThan(0), "No secret keys generated");
+
+            // Determinism check: repeated derivation with the same parameters gives the same keys
+            using EccPgpContext ctx2 = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            ctx2.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, account, channel, index);
+            var publicKeys2 = ctx2.EnumeratePublicKeyRings().ToList();
+            var secretKeys2 = ctx2.EnumerateSecretKeyRings().ToList();
+            Assert.That(publicKeys.Count, Is.EqualTo(publicKeys2.Count), "Public key count mismatch");
+            Assert.That(secretKeys.Count, Is.EqualTo(secretKeys2.Count), "Secret key count mismatch");
+            Assert.That(publicKeys[0].GetPublicKey().GetFingerprint(), Is.EqualTo(publicKeys2[0].GetPublicKey().GetFingerprint()), "Public key fingerprint mismatch");
+            Assert.That(secretKeys[0].GetSecretKey().KeyId, Is.EqualTo(secretKeys2[0].GetSecretKey().KeyId), "Secret key id mismatch");
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecDifferentValidParameters()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            int[] accounts = { 0, 1 };
+            int[] channels = { 10, 20 };
+            int[] indices = { 0, 1 };
+            foreach (var account in accounts)
+            {
+                foreach (var channel in channels)
+                {
+                    foreach (var index in indices)
+                    {
+                        ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, account, channel, index);
+                        var publicKeys = ctx.EnumeratePublicKeyRings().ToList();
+                        var secretKeys = ctx.EnumerateSecretKeyRings().ToList();
+                        Assert.That(publicKeys.Count, Is.GreaterThan(0));
+                        Assert.That(secretKeys.Count, Is.GreaterThan(0));
+                        ctx.Delete(publicKeys[0]);
+                        ctx.Delete(secretKeys[0]);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecBoundaryValues()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, 0, 0, 0, 0);
+            ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+            var publicKeys = ctx.EnumeratePublicKeyRings().ToList();
+            var secretKeys = ctx.EnumerateSecretKeyRings().ToList();
+            Assert.That(publicKeys.Count, Is.GreaterThan(0));
+            Assert.That(secretKeys.Count, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecInvalidParametersThrows()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            Assert.Throws<ArgumentNullException>(() => ctx.GeneratePgpKeysByBip44(null, userIdentity, CoinType, 0, 10, 0));
+            Assert.Throws<ArgumentNullException>(() => ctx.GeneratePgpKeysByBip44(TestData.MasterKey, null, CoinType, 0, 10, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, -1, 10, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, -1));
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecUniqueness()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, 0);
+            var publicKeys1 = ctx.EnumeratePublicKeyRings().Select(x => x.GetPublicKey().GetFingerprint()).ToList();
+            var secretKeys1 = ctx.EnumerateSecretKeyRings().Select(x => x.GetSecretKey().KeyId).ToList();
+            ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, 1);
+            var publicKeys2 = ctx.EnumeratePublicKeyRings().Select(x => x.GetPublicKey().GetFingerprint()).ToList();
+            var secretKeys2 = ctx.EnumerateSecretKeyRings().Select(x => x.GetSecretKey().KeyId).ToList();
+            // Check that new keys are unique by fingerprint/KeyId
+            bool foundUniquePublic = publicKeys2.Except(publicKeys1).Any();
+            bool foundUniqueSecret = secretKeys2.Except(secretKeys1).Any();
+            Assert.That(foundUniquePublic, Is.True, "No unique public key generated");
+            Assert.That(foundUniqueSecret, Is.True, "No unique secret key generated");
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecRepeatability()
+        {
+            using EccPgpContext ctx1 = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            using EccPgpContext ctx2 = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            ctx1.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, 0);
+            ctx2.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, 0);
+            var publicKeys1 = ctx1.EnumeratePublicKeyRings().ToList();
+            var secretKeys1 = ctx1.EnumerateSecretKeyRings().ToList();
+            var publicKeys2 = ctx2.EnumeratePublicKeyRings().ToList();
+            var secretKeys2 = ctx2.EnumerateSecretKeyRings().ToList();
+            Assert.That(publicKeys1[0].GetPublicKey().GetFingerprint(), Is.EqualTo(publicKeys2[0].GetPublicKey().GetFingerprint()));
+            Assert.That(secretKeys1[0].GetSecretKey().KeyId, Is.EqualTo(secretKeys2[0].GetSecretKey().KeyId));
+        }
+
+        [Test]
+        public async Task DeriveKeyForDecBulkGeneration()
+        {
+            using EccPgpContext ctx = await InitializeEccPgpContextAsync().ConfigureAwait(false);
+            string userIdentity = TestData.GetAccount().GetPgpIdentity();
+            for (int i = 0; i < 5; i++)
+            {
+                ctx.GeneratePgpKeysByBip44(TestData.MasterKey, userIdentity, CoinType, 0, 10, i);
+            }
+            var publicKeys = ctx.EnumeratePublicKeyRings().ToList();
+            var secretKeys = ctx.EnumerateSecretKeyRings().ToList();
+            Assert.That(publicKeys.Count, Is.GreaterThanOrEqualTo(5));
+            Assert.That(secretKeys.Count, Is.GreaterThanOrEqualTo(5));
         }
     }
 }

--- a/TuviPgpLibTests/EntitiesTests.cs
+++ b/TuviPgpLibTests/EntitiesTests.cs
@@ -45,7 +45,7 @@ namespace TuviPgpLibTests
         {
             using (TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false))
             {
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
                 var publicKeyInfo = ctx.GetPublicKeysInfo().First();
                 Assert.That(publicKeyInfo.Algorithm, Is.EqualTo("ECDsa"));
                 Assert.That(publicKeyInfo.BitStrength, Is.EqualTo(256));

--- a/TuviPgpLibTests/TuviPgpContextTests.cs
+++ b/TuviPgpLibTests/TuviPgpContextTests.cs
@@ -50,7 +50,7 @@ namespace TuviPgpLibTests
             {
                 var identities = new List<UserIdentity> { TestData.GetAccount().GetUserIdentity() };
 
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
                 ctx.ExportPublicKeys(identities, publicKeyData, isArmored);
                 ctx.ExportSecretKeys(TestData.GetAccount().GetPgpIdentity(), secretKeyData, isArmored);
 
@@ -76,11 +76,11 @@ namespace TuviPgpLibTests
             using Stream secretKeyData = new MemoryStream();
             using (TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false))
             {
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
                 var publicKeyId = ctx.GetPublicKeysInfo().First().KeyId;
 
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetSecondAccount().GetPgpIdentity());
-                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetThirdAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetSecondAccount().GetPgpIdentity(), TestData.GetSecondAccount().GetPgpIdentity());
+                ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetThirdAccount().GetPgpIdentity(), TestData.GetThirdAccount().GetPgpIdentity());
                 Assert.That(ctx.GetPublicKeysInfo().Count, Is.EqualTo(3));
 
                 Assert.DoesNotThrowAsync(() => ctx.ExportPublicKeyRingAsync(publicKeyId, publicKeyArmored, default));
@@ -136,7 +136,7 @@ namespace TuviPgpLibTests
         public async Task SecretKeyExistAsync()
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             bool isKeyExist = ctx.IsSecretKeyExist(TestData.GetAccount().GetUserIdentity());
 
             Assert.That(isKeyExist, Is.True, "Secret key has to exist");
@@ -146,7 +146,7 @@ namespace TuviPgpLibTests
         public async Task SecretKeyNotExistAsync()
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.WrongPgpIdentity);
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.WrongPgpIdentity, TestData.WrongPgpIdentity);
             bool isKeyExist = ctx.IsSecretKeyExist(TestData.GetAccount().GetUserIdentity());
 
             Assert.That(isKeyExist, Is.False, "Secret key has not to exist");
@@ -157,7 +157,7 @@ namespace TuviPgpLibTests
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
 
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             var keysInfo = ctx.GetPublicKeysInfo(); 
 
             Assert.That(keysInfo.Count, Is.EqualTo(1));
@@ -173,7 +173,7 @@ namespace TuviPgpLibTests
         {
             using TuviPgpContext ctx = await InitializeTuviPgpContextAsync().ConfigureAwait(false);
             UserIdentity? nullIdentity = null;
-            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity());
+            ctx.DeriveKeyPair(TestData.MasterKey, TestData.GetAccount().GetPgpIdentity(), TestData.GetAccount().GetPgpIdentity());
             Assert.Throws<ArgumentNullException>(() => ctx.IsSecretKeyExist(nullIdentity));
         }
 


### PR DESCRIPTION
- Added `GeneratePgpKeysByBip44` method to support BIP44 hierarchical deterministic key derivation (m/44'/coin'/account'/channel/index) for secp256k1-based PGP keys.
- Refactored key derivation to use string-based tags ("Signature", "Encryption") instead of enum-based `KeyCreationReason` for clarity and consistency.
- Introduced `GenerateEccKeyPairFromPrivateKey` method to streamline ECC key pair generation from a private derivation key.
- Added `CreatePgpPublicKey` method to encapsulate PGP public key creation logic for ECDH and ECDSA algorithms.
- Consolidated key ring generation logic into `CreatePgpKeyRingGenerator` for reusability across tag-based and BIP44 derivation methods.
- Updated default encryption to AES-256 and hash algorithm to SHA-256 for enhanced security.
- Removed obsolete `DeriveKeyPair` and `DeriveKeyForDec` methods.
- Improved documentation with detailed XML comments for better clarity and maintainability.
- Updated copyright year to 2025.